### PR TITLE
Unique ID in JSON output

### DIFF
--- a/src/github.com/gonium/gosdm630/cmd/sdm630_httpd/main.go
+++ b/src/github.com/gonium/gosdm630/cmd/sdm630_httpd/main.go
@@ -46,8 +46,17 @@ func main() {
 			Usage: `MODBUS device ID to query, separated by comma. 
 			Example: -d 11,12,13`,
 		},
+		cli.StringFlag{
+			Name: "unique_id_format, f",
+			Value: "Instrument%d",
+			Usage: `Unique ID format.
+			Example: -f Instrument%d
+			The %d is replaced by the device ID`,
+		},
 	}
 	app.Action = func(c *cli.Context) {
+		// Set unique ID format
+		sdm630.UniqueIdFormat = c.String("unique_id_format")
 		// Parse the device_list parameter
 		deviceslice := strings.Split(c.String("device_list"), ",")
 		devids := make([]uint8, 0, len(deviceslice))

--- a/src/github.com/gonium/gosdm630/datagram_test.go
+++ b/src/github.com/gonium/gosdm630/datagram_test.go
@@ -11,6 +11,7 @@ func TestQuerySnipMerge(t *testing.T) {
 		Timestamp:      time.Now(),
 		Unix:           time.Now().Unix(),
 		ModbusDeviceId: 1,
+		UniqueId: "Instrument1",
 		Power: sdm630.ThreePhaseReadings{
 			L1: 1, L2: 2, L3: 3,
 		},

--- a/src/github.com/gonium/gosdm630/measurementcache.go
+++ b/src/github.com/gonium/gosdm630/measurementcache.go
@@ -62,6 +62,7 @@ func (mc *MeasurementCache) Consume() {
 			devreading.lastminutereadings = append(devreading.lastminutereadings, reading)
 		} else {
 			reading := Readings{
+				UniqueId: fmt.Sprintf(UniqueIdFormat, devid),
 				ModbusDeviceId: devid,
 			}
 			reading.MergeSnip(snip)
@@ -103,7 +104,7 @@ func (mc *MeasurementCache) GetMinuteAvg(id byte) (Readings, error) {
 	measurements := mc.deviceReadings[id].lastminutereadings
 	lastminute := measurements.NotOlderThan(time.Now().Add(-1 *
 		time.Minute))
-	avg := Readings{ModbusDeviceId: id}
+	avg := Readings{UniqueId: fmt.Sprintf(UniqueIdFormat, id), ModbusDeviceId: id}
 	for _, r := range lastminute {
 		var err error
 		avg, err = r.add(&avg)


### PR DESCRIPTION
This PR adds a unique ID to the JSON output. It can be useful for instrument identification purposes in a situation with multiple instances of gosdm630 serving JSON from dynamic IPs.