### PR TITLE
Ignore editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Editor files
+*~
+*.sw[op]
+
 # gb-compiled binaries
 bin
 pkg


### PR DESCRIPTION
Simple addition to .gitignore to ignore swap/backup files commonly created by various text editors.