### PR TITLE
Run scheduler in go routine (leftover from #39)

### DIFF
--- a/src/github.com/gonium/gosdm630/cmd/sdm630/main.go
+++ b/src/github.com/gonium/gosdm630/cmd/sdm630/main.go
@@ -171,7 +171,7 @@ func main() {
 
 		// scheduler and meter data channel
 		scheduler, snips := sdm630.SetupScheduler(meters, qe)
-		scheduler.Run()
+		go scheduler.Run()
 
 		// tee that broadcasts meter messages to multiple recipients
 		tee := sdm630.NewQuerySnipBroadcaster(snips)

--- a/src/github.com/gonium/gosdm630/cmd/sdm630_httpd/main.go
+++ b/src/github.com/gonium/gosdm630/cmd/sdm630_httpd/main.go
@@ -119,7 +119,7 @@ func main() {
 
 		// scheduler and meter data channel
 		scheduler, snips := sdm630.SetupScheduler(meters, qe)
-		scheduler.Run()
+		go scheduler.Run()
 
 		// tee that broadcasts meter messages to multiple recipients
 		tee := sdm630.NewQuerySnipBroadcaster(snips)


### PR DESCRIPTION
Critical fix - not running scheduler in go routine will stop loop after first reading.