### PR TITLE
Refactor meter implementation

### DIFF
--- a/cmd/sdm630/main.go
+++ b/cmd/sdm630/main.go
@@ -127,7 +127,6 @@ func main() {
 		deviceslice := strings.Split(c.String("device_list"), ",")
 		meters := make(map[uint8]*sdm630.Meter)
 		for _, meterdef := range deviceslice {
-			var meter *sdm630.Meter
 			splitdef := strings.Split(meterdef, ":")
 			if len(splitdef) != 2 {
 				log.Fatalf("Cannot parse device definition %s. See -h for help.", meterdef)
@@ -137,24 +136,8 @@ func main() {
 			if err != nil {
 				log.Fatalf("Error parsing device id %s: %s. See -h for help.", meterdef, err.Error())
 			}
-			metertype = strings.ToUpper(metertype)
-			switch metertype {
-			case sdm630.METERTYPE_JANITZA:
-				meter = sdm630.NewMeter(sdm630.METERTYPE_JANITZA,
-					uint8(id), sdm630.NewJanitzaRoundRobinScheduler(),
-					DEFAULT_METER_STORE_SECONDS)
-			case sdm630.METERTYPE_SDM:
-				meter = sdm630.NewMeter(sdm630.METERTYPE_SDM,
-					uint8(id), sdm630.NewSDMRoundRobinScheduler(),
-					DEFAULT_METER_STORE_SECONDS)
-			case sdm630.METERTYPE_DZG:
-				log.Println(`WARNING: The DZG DVH 4013 does not report the same
-				measurements as the other meters. Only limited functionality is
-				implemented.`)
-				meter = sdm630.NewMeter(sdm630.METERTYPE_DZG,
-					uint8(id), sdm630.NewDZGRoundRobinScheduler(),
-					DEFAULT_METER_STORE_SECONDS)
-			default:
+			meter, err := sdm630.NewMeterByType(metertype, uint8(id), DEFAULT_METER_STORE_SECONDS)
+			if err != nil {
 				log.Fatalf("Unknown meter type %s for device %d. See -h for help.", metertype, id)
 			}
 			meters[uint8(id)] = meter

--- a/cmd/sdm630_httpd/main.go
+++ b/cmd/sdm630_httpd/main.go
@@ -75,7 +75,6 @@ func main() {
 		deviceslice := strings.Split(c.String("device_list"), ",")
 		meters := make(map[uint8]*sdm630.Meter)
 		for _, meterdef := range deviceslice {
-			var meter *sdm630.Meter
 			splitdef := strings.Split(meterdef, ":")
 			if len(splitdef) != 2 {
 				log.Fatalf("Cannot parse device definition %s. See -h for help.", meterdef)
@@ -85,24 +84,8 @@ func main() {
 			if err != nil {
 				log.Fatalf("Error parsing device id %s: %s. See -h for help.", meterdef, err.Error())
 			}
-			metertype = strings.ToUpper(metertype)
-			switch metertype {
-			case sdm630.METERTYPE_JANITZA:
-				meter = sdm630.NewMeter(sdm630.METERTYPE_JANITZA,
-					uint8(id), sdm630.NewJanitzaRoundRobinScheduler(),
-					DEFAULT_METER_STORE_SECONDS)
-			case sdm630.METERTYPE_SDM:
-				meter = sdm630.NewMeter(sdm630.METERTYPE_SDM,
-					uint8(id), sdm630.NewSDMRoundRobinScheduler(),
-					DEFAULT_METER_STORE_SECONDS)
-			case sdm630.METERTYPE_DZG:
-				log.Println(`WARNING: The DZG DVH 4013 does not report the same
-				measurements as the other meters. Only limited functionality is 
-				implemented.`)
-				meter = sdm630.NewMeter(sdm630.METERTYPE_DZG,
-					uint8(id), sdm630.NewDZGRoundRobinScheduler(),
-					DEFAULT_METER_STORE_SECONDS)
-			default:
+			meter, err := sdm630.NewMeterByType(metertype, uint8(id), DEFAULT_METER_STORE_SECONDS)
+			if err != nil {
 				log.Fatalf("Unknown meter type %s for device %d. See -h for help.", metertype, id)
 			}
 			meters[uint8(id)] = meter

--- a/datagram.go
+++ b/datagram.go
@@ -260,6 +260,7 @@ type QuerySnip struct {
 	DeviceId      uint8
 	FuncCode      uint8  `json:"-"`
 	OpCode        uint16 `json:"-"`
+	ReadLen       uint16 `json:"-"`
 	Value         float64
 	IEC61850      string
 	Description   string

--- a/dzg.go
+++ b/dzg.go
@@ -1,0 +1,82 @@
+package sdm630
+
+import (
+	"math"
+)
+
+const (
+	METERTYPE_DZG = "DZG"
+
+	/***
+	 * Opcodes for DZG DVH4014.
+	 * See "User Manual DVH4013", not public.
+	 */
+	OpCodeDZGTotalImportPower = 0x0000
+	OpCodeDZGTotalExportPower = 0x0002
+	OpCodeDZGL1Voltage        = 0x0004
+	OpCodeDZGL2Voltage        = 0x0006
+	OpCodeDZGL3Voltage        = 0x0008
+	OpCodeDZGL1Current        = 0x000A
+	OpCodeDZGL2Current        = 0x000C
+	OpCodeDZGL3Current        = 0x000E
+	OpCodeDZGL1Import         = 0x4020
+	OpCodeDZGL2Import         = 0x4040
+	OpCodeDZGL3Import         = 0x4060
+	OpCodeDZGTotalImport      = 0x4000
+	OpCodeDZGL1Export         = 0x4120
+	OpCodeDZGL2Export         = 0x4140
+	OpCodeDZGL3Export         = 0x4160
+	OpCodeDZGTotalExport      = 0x4100
+)
+
+type DZGProducer struct {
+}
+
+func NewDZGProducer() *DZGProducer {
+	return &DZGProducer{}
+}
+
+func (p *DZGProducer) snip(devid uint8, opcode uint16, iec string, scaler ...float64) QuerySnip {
+	transform := RTU32ToFloat64 // default conversion
+	if len(scaler) > 0 {
+		transform = MakeRTU32ScaledIntToFloat64(scaler[0])
+	}
+
+	snip := QuerySnip{
+		DeviceId:    devid,
+		FuncCode:    ReadHoldingReg,
+		OpCode:      opcode,
+		ReadLen:     2,
+		Value:       math.NaN(),
+		IEC61850:    iec,
+		Description: GetIecDescription(iec),
+		Transform:   transform,
+	}
+	return snip
+}
+
+func (p *DZGProducer) Probe(devid uint8) QuerySnip {
+	return p.snip(devid, OpCodeDZGL1Voltage, "VolLocPhsA", 100)
+}
+
+func (p *DZGProducer) Produce(devid uint8) (res []QuerySnip) {
+	res = append(res, p.snip(devid, OpCodeDZGL1Voltage, "VolLocPhsA", 100))
+	res = append(res, p.snip(devid, OpCodeDZGL2Voltage, "VolLocPhsB", 100))
+	res = append(res, p.snip(devid, OpCodeDZGL3Voltage, "VolLocPhsC", 100))
+
+	res = append(res, p.snip(devid, OpCodeDZGL1Current, "AmpLocPhsA", 1000))
+	res = append(res, p.snip(devid, OpCodeDZGL2Current, "AmpLocPhsB", 1000))
+	res = append(res, p.snip(devid, OpCodeDZGL3Current, "AmpLocPhsC", 1000))
+
+	res = append(res, p.snip(devid, OpCodeDZGL1Import, "TotkWhImportPhsA"))
+	res = append(res, p.snip(devid, OpCodeDZGL2Import, "TotkWhImportPhsB"))
+	res = append(res, p.snip(devid, OpCodeDZGL3Import, "TotkWhImportPhsC"))
+	res = append(res, p.snip(devid, OpCodeDZGTotalImport, "TotkWhImport", 1000))
+
+	res = append(res, p.snip(devid, OpCodeDZGL1Export, "TotkWhExportPhsA"))
+	res = append(res, p.snip(devid, OpCodeDZGL2Export, "TotkWhExportPhsB"))
+	res = append(res, p.snip(devid, OpCodeDZGL3Export, "TotkWhExportPhsC"))
+	res = append(res, p.snip(devid, OpCodeDZGTotalExport, "TotkWhExport", 1000))
+
+	return res
+}

--- a/iec.go
+++ b/iec.go
@@ -1,0 +1,39 @@
+package sdm630
+
+import "log"
+
+var iec = map[string]string{
+	"AmpLocPhsA":       "L1 Current (A)",
+	"AmpLocPhsB":       "L2 Current (A)",
+	"AmpLocPhsC":       "L3 Current (A)",
+	"AngLocPhsA":       "L1 Cosphi",
+	"AngLocPhsB":       "L2 Cosphi",
+	"AngLocPhsC":       "L3 Cosphi",
+	"Freq":             "Frequency of supply voltages",
+	"ThdVol":           "Average voltage to neutral THD (%)",
+	"ThdVolPhsA":       "L1 Voltage to neutral THD (%)",
+	"ThdVolPhsB":       "L2 Voltage to neutral THD (%)",
+	"ThdVolPhsC":       "L3 Voltage to neutral THD (%)",
+	"TotkWhExport":     "Total Export (kWh)",
+	"TotkWhExportPhsA": "L1 Export (kWh)",
+	"TotkWhExportPhsB": "L2 Export (kWh)",
+	"TotkWhExportPhsC": "L3 Export (kWh)",
+	"TotkWhImport":     "Total Import (kWh)",
+	"TotkWhImportPhsA": "L1 Import (kWh)",
+	"TotkWhImportPhsB": "L2 Import (kWh)",
+	"TotkWhImportPhsC": "L3 Import (kWh)",
+	"VolLocPhsA":       "L1 Voltage (V)",
+	"VolLocPhsB":       "L2 Voltage (V)",
+	"VolLocPhsC":       "L3 Voltage (V)",
+	"WLocPhsA":         "L1 Power (W)",
+	"WLocPhsB":         "L2 Power (W)",
+	"WLocPhsC":         "L3 Power (W)",
+}
+
+func GetIecDescription(key string) string {
+	description, ok := iec[key]
+	if !ok {
+		log.Fatalf("Undefined IEC code %s", key)
+	}
+	return description
+}

--- a/janitza.go
+++ b/janitza.go
@@ -1,0 +1,86 @@
+package sdm630
+
+import "math"
+
+const (
+	METERTYPE_JANITZA = "JANITZA"
+
+	/***
+	 * Opcodes for Janitza B23.
+	 * See https://www.janitza.de/betriebsanleitungen.html?file=files/download/manuals/current/B-Series/MID-Energy-Meters-Product-Manual.pdf
+	 */
+	OpCodeJanitzaL1Voltage   = 0x4A38
+	OpCodeJanitzaL2Voltage   = 0x4A3A
+	OpCodeJanitzaL3Voltage   = 0x4A3C
+	OpCodeJanitzaL1Current   = 0x4A44
+	OpCodeJanitzaL2Current   = 0x4A46
+	OpCodeJanitzaL3Current   = 0x4A48
+	OpCodeJanitzaL1Power     = 0x4A4C
+	OpCodeJanitzaL2Power     = 0x4A4E
+	OpCodeJanitzaL3Power     = 0x4A50
+	OpCodeJanitzaL1Import    = 0x4A76
+	OpCodeJanitzaL2Import    = 0x4A78
+	OpCodeJanitzaL3Import    = 0x4A7A
+	OpCodeJanitzaTotalImport = 0x4A7C
+	OpCodeJanitzaL1Export    = 0x4A7E
+	OpCodeJanitzaL2Export    = 0x4A80
+	OpCodeJanitzaL3Export    = 0x4A82
+	OpCodeJanitzaTotalExport = 0x4A84
+	OpCodeJanitzaL1Cosphi    = 0x4A64
+	OpCodeJanitzaL2Cosphi    = 0x4A66
+	OpCodeJanitzaL3Cosphi    = 0x4A68
+)
+
+type JanitzaProducer struct {
+}
+
+func NewJanitzaProducer() *JanitzaProducer {
+	return &JanitzaProducer{}
+}
+
+func (p *JanitzaProducer) snip(devid uint8, opcode uint16, iec string) QuerySnip {
+	snip := QuerySnip{
+		DeviceId:    devid,
+		FuncCode:    ReadHoldingReg,
+		OpCode:      opcode,
+		ReadLen:     2,
+		Value:       math.NaN(),
+		IEC61850:    iec,
+		Description: GetIecDescription(iec),
+		Transform:   RTU32ToFloat64,
+	}
+	return snip
+}
+
+func (p *JanitzaProducer) Probe(devid uint8) QuerySnip {
+	return p.snip(devid, OpCodeJanitzaL1Voltage, "VolLocPhsA")
+}
+
+func (p *JanitzaProducer) Produce(devid uint8) (res []QuerySnip) {
+	res = append(res, p.snip(devid, OpCodeJanitzaL1Voltage, "VolLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL2Voltage, "VolLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL3Voltage, "VolLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeJanitzaL1Current, "AmpLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL2Current, "AmpLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL3Current, "AmpLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeJanitzaL1Power, "WLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL2Power, "WLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL3Power, "WLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeJanitzaL1Cosphi, "AngLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL2Cosphi, "AngLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL3Cosphi, "AngLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeJanitzaL1Import, "TotkWhImportPhsA"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL2Import, "TotkWhImportPhsB"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL3Import, "TotkWhImportPhsC"))
+	res = append(res, p.snip(devid, OpCodeJanitzaTotalImport, "TotkWhImport"))
+
+	res = append(res, p.snip(devid, OpCodeJanitzaL1Export, "TotkWhExportPhsA"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL2Export, "TotkWhExportPhsB"))
+	res = append(res, p.snip(devid, OpCodeJanitzaL3Export, "TotkWhExportPhsC"))
+	res = append(res, p.snip(devid, OpCodeJanitzaTotalExport, "TotkWhExport"))
+	return res
+}

--- a/modbus.go
+++ b/modbus.go
@@ -160,8 +160,8 @@ func (q *ModbusEngine) Transform(
 			// convert bytes to value
 			snip.Value = snip.Transform(reading)
 			snip.ReadTimestamp = time.Now()
-
 			outputStream <- snip
+
 			successSnip := ControlSnip{
 				Type:     CONTROLSNIP_OK,
 				Message:  "OK",

--- a/modbus.go
+++ b/modbus.go
@@ -18,90 +18,6 @@ const (
 )
 
 const (
-	/***
-	 * Opcodes as defined by Eastron.
-	 * See http://bg-etech.de/download/manual/SDM630Register.pdf
-	 * Please note that this is the superset of all SDM devices - some
-	 * opcodes might not work on some devices.
-	 */
-	OpCodeSDML1Voltage   = 0x0000
-	OpCodeSDML2Voltage   = 0x0002
-	OpCodeSDML3Voltage   = 0x0004
-	OpCodeSDML1Current   = 0x0006
-	OpCodeSDML2Current   = 0x0008
-	OpCodeSDML3Current   = 0x000A
-	OpCodeSDML1Power     = 0x000C
-	OpCodeSDML2Power     = 0x000E
-	OpCodeSDML3Power     = 0x0010
-	OpCodeSDML1Import    = 0x015a
-	OpCodeSDML2Import    = 0x015c
-	OpCodeSDML3Import    = 0x015e
-	OpCodeSDMTotalImport = 0x0048
-	OpCodeSDML1Export    = 0x0160
-	OpCodeSDML2Export    = 0x0162
-	OpCodeSDML3Export    = 0x0164
-	OpCodeSDMTotalExport = 0x004a
-	OpCodeSDML1Cosphi    = 0x001e
-	OpCodeSDML2Cosphi    = 0x0020
-	OpCodeSDML3Cosphi    = 0x0022
-	//OpCodeL1THDCurrent         = 0x00F0
-	//OpCodeL2THDCurrent         = 0x00F2
-	//OpCodeL3THDCurrent         = 0x00F4
-	//OpCodeAvgTHDCurrent        = 0x00Fa
-	OpCodeSDML1THDVoltageNeutral  = 0x00ea
-	OpCodeSDML2THDVoltageNeutral  = 0x00ec
-	OpCodeSDML3THDVoltageNeutral  = 0x00ee
-	OpCodeSDMAvgTHDVoltageNeutral = 0x00F8
-	OpCodeSDMFrequency            = 0x0046
-
-	/***
-	 * Opcodes for Janitza B23.
-	 * See https://www.janitza.de/betriebsanleitungen.html?file=files/download/manuals/current/B-Series/MID-Energy-Meters-Product-Manual.pdf
-	 */
-	OpCodeJanitzaL1Voltage   = 0x4A38
-	OpCodeJanitzaL2Voltage   = 0x4A3A
-	OpCodeJanitzaL3Voltage   = 0x4A3C
-	OpCodeJanitzaL1Current   = 0x4A44
-	OpCodeJanitzaL2Current   = 0x4A46
-	OpCodeJanitzaL3Current   = 0x4A48
-	OpCodeJanitzaL1Power     = 0x4A4C
-	OpCodeJanitzaL2Power     = 0x4A4E
-	OpCodeJanitzaL3Power     = 0x4A50
-	OpCodeJanitzaL1Import    = 0x4A76
-	OpCodeJanitzaL2Import    = 0x4A78
-	OpCodeJanitzaL3Import    = 0x4A7A
-	OpCodeJanitzaTotalImport = 0x4A7C
-	OpCodeJanitzaL1Export    = 0x4A7E
-	OpCodeJanitzaL2Export    = 0x4A80
-	OpCodeJanitzaL3Export    = 0x4A82
-	OpCodeJanitzaTotalExport = 0x4A84
-	OpCodeJanitzaL1Cosphi    = 0x4A64
-	OpCodeJanitzaL2Cosphi    = 0x4A66
-	OpCodeJanitzaL3Cosphi    = 0x4A68
-
-	/***
-	 * Opcodes for DZG DVH4014.
-	 * See "User Manual DVH4013", not public.
-	 */
-	OpCodeDZGTotalImportPower = 0x0000
-	OpCodeDZGTotalExportPower = 0x0002
-	OpCodeDZGL1Voltage        = 0x0004
-	OpCodeDZGL2Voltage        = 0x0006
-	OpCodeDZGL3Voltage        = 0x0008
-	OpCodeDZGL1Current        = 0x000A
-	OpCodeDZGL2Current        = 0x000C
-	OpCodeDZGL3Current        = 0x000E
-	OpCodeDZGL1Import         = 0x4020
-	OpCodeDZGL2Import         = 0x4040
-	OpCodeDZGL3Import         = 0x4060
-	OpCodeDZGTotalImport      = 0x4000
-	OpCodeDZGL1Export         = 0x4120
-	OpCodeDZGL2Export         = 0x4140
-	OpCodeDZGL3Export         = 0x4160
-	OpCodeDZGTotalExport      = 0x4100
-)
-
-const (
 	ModbusComset2400_8N1  = 1
 	ModbusComset9600_8N1  = 2
 	ModbusComset19200_8N1 = 3
@@ -183,22 +99,21 @@ func NewModbusEngine(
 	}
 }
 
-func (q *ModbusEngine) retrieveOpCode(deviceid uint8, funccode uint8,
-	opcode uint16) (retval []byte, err error) {
+func (q *ModbusEngine) query(snip QuerySnip) (retval []byte, err error) {
 	q.status.IncreaseModbusRequestCounter()
 	// update the slave id in the handler
-	q.handler.SlaveId = deviceid
-	switch funccode {
+	q.handler.SlaveId = snip.DeviceId
+	switch snip.FuncCode {
 	case ReadInputReg:
-		retval, err = q.client.ReadInputRegisters(opcode, 2)
+		retval, err = q.client.ReadInputRegisters(snip.OpCode, snip.ReadLen)
 	case ReadHoldingReg:
-		retval, err = q.client.ReadHoldingRegisters(opcode, 2)
+		retval, err = q.client.ReadHoldingRegisters(snip.OpCode, snip.ReadLen)
 	default:
 		log.Fatalf("Unknown function code %d - cannot query device.",
-			funccode)
+			snip.FuncCode)
 	}
 	if err != nil && q.verbose {
-		log.Printf("Failed to retrieve opcode 0x%x, error was: %s\r\n", opcode, err.Error())
+		log.Printf("Failed to retrieve opcode 0x%x, error was: %s\r\n", snip.OpCode, err.Error())
 	}
 	return retval, err
 }
@@ -216,18 +131,14 @@ func (q *ModbusEngine) Transform(
 		if previousDeviceId != snip.DeviceId {
 			time.Sleep(time.Duration(100) * time.Millisecond)
 		}
-		//if snip.OpCode == 0x00 {
-		//	log.Printf("Skipping invalid Snip %+v", snip)
-		//} else {
-		//log.Printf("Executing Snip %+v", snip)
 		previousDeviceId = snip.DeviceId
-		//		value := q.queryOrFail(snip.DeviceId, snip.FuncCode, snip.OpCode, errorStream)
 
 		var err error
 		var reading []byte
+
 		tryCnt := 0
 		for tryCnt = 0; tryCnt < MaxRetryCount; tryCnt++ {
-			reading, err = q.retrieveOpCode(snip.DeviceId, snip.FuncCode, snip.OpCode)
+			reading, err = q.query(snip)
 			if err != nil {
 				q.status.IncreaseModbusReconnectCounter()
 				log.Printf("Device %d failed to respond - retry attempt %d of %d",
@@ -237,6 +148,7 @@ func (q *ModbusEngine) Transform(
 				break
 			}
 		}
+
 		if tryCnt == MaxRetryCount {
 			errorSnip := ControlSnip{
 				Type:     CONTROLSNIP_ERROR,
@@ -245,14 +157,10 @@ func (q *ModbusEngine) Transform(
 			}
 			controlStream <- errorSnip
 		} else {
-			//Now: convert bytes to value. Assume float64 conversion by
-			//default.
-			if snip.Transform != nil {
-				snip.Value = snip.Transform(reading)
-			} else {
-				snip.Value = rtuToFloat64(reading)
-			}
+			// convert bytes to value
+			snip.Value = snip.Transform(reading)
 			snip.ReadTimestamp = time.Now()
+
 			outputStream <- snip
 			successSnip := ControlSnip{
 				Type:     CONTROLSNIP_OK,
@@ -266,82 +174,102 @@ func (q *ModbusEngine) Transform(
 
 func (q *ModbusEngine) Scan() {
 	type Device struct {
-		BusId      uint8
+		DeviceId   uint8
 		DeviceType MeterType
 	}
+
 	devicelist := make([]Device, 0)
 	oldtimeout := q.handler.Timeout
 	q.handler.Timeout = 50 * time.Millisecond
 	log.Printf("Starting bus scan")
+
+	probe := func(meterType MeterType, snip QuerySnip) bool {
+		value, err := q.query(snip)
+		if err == nil {
+			log.Printf("Device %d: %s type device found, %s: %.2f\r\n",
+				snip.DeviceId,
+				meterType,
+				GetIecDescription(snip.IEC61850),
+				snip.Transform(value))
+			dev := Device{
+				DeviceId:   snip.DeviceId,
+				DeviceType: meterType,
+			}
+			devicelist = append(devicelist, dev)
+			return true
+		}
+		return false
+	}
+
 	// loop over all valid slave adresses
 	var devid uint8
 	for devid = 1; devid <= 247; devid++ {
-		// Check if a SDM device responds: try to query L1 voltage
-		voltage_L1, err := q.retrieveOpCode(devid, ReadInputReg, OpCodeSDML1Voltage)
-		if err == nil {
-			log.Printf("Device %d: SDM type device found, L1 voltage: %.2f\r\n", devid, rtuToFloat64(voltage_L1))
-			dev := Device{
-				BusId:      devid,
-				DeviceType: METERTYPE_SDM,
-			}
-			devicelist = append(devicelist, dev)
-		} else {
-			// Check if a Janitza device responds: try to query L1 voltage
-			voltage_L1, err := q.retrieveOpCode(devid, ReadHoldingReg, OpCodeJanitzaL1Voltage)
-			if err == nil {
-				log.Printf("Device %d: Janitza type device found, L1 voltage: %.2f\r\n", devid, rtuToFloat64(voltage_L1))
-				dev := Device{
-					BusId:      devid,
-					DeviceType: METERTYPE_JANITZA,
-				}
-				devicelist = append(devicelist, dev)
-			} else {
-				// Check if a Janitza device responds: try to query L1 voltage
-				voltage_L1, err := q.retrieveOpCode(devid, ReadHoldingReg, OpCodeDZGL1Voltage)
-				if err == nil {
-					log.Printf("Device %d: DZG type device found, L1 voltage: %.2f\r\n", devid, rtuToFloat64(voltage_L1))
-					dev := Device{
-						BusId:      devid,
-						DeviceType: METERTYPE_DZG,
-					}
-					devicelist = append(devicelist, dev)
-				} else {
-					log.Printf("Device %d: n/a\r\n", devid)
-				}
-			}
+		if probe(METERTYPE_SDM, NewSDMProducer().Probe(devid)) {
+			continue
 		}
+		if probe(METERTYPE_JANITZA, NewJanitzaProducer().Probe(devid)) {
+			continue
+		}
+		if probe(METERTYPE_DZG, NewDZGProducer().Probe(devid)) {
+			continue
+		}
+
+		log.Printf("Device %d: n/a\r\n", devid)
+
 		// give the bus some time to recover before querying the next device
 		time.Sleep(time.Duration(40) * time.Millisecond)
 	}
+
 	// restore timeout to old value
 	q.handler.Timeout = oldtimeout
 	log.Printf("Found %d active devices:\r\n", len(devicelist))
 	for _, device := range devicelist {
-		log.Printf("* slave address %d: type %s\r\n", device.BusId,
+		log.Printf("* slave address %d: type %s\r\n", device.DeviceId,
 			device.DeviceType)
 	}
 	log.Println("WARNING: This lists only the devices that responded to " +
-		"a known L1 voltage request. Devices with " +
-		"different function code definitions might not be detected.")
+		"a known probe request. Devices with different " +
+		"function code definitions might not be detected.")
 }
 
-// Transform functions to convert RTU bytes to meaningfull data types.
+// RTUTransform functions convert RTU bytes to meaningful data types.
 type RTUTransform func([]byte) float64
 
-func rtuScaledIntToFloat64(b []byte, scalar float64) float64 {
+// RTU32ToFloat64 converts 32 bit readings
+func RTU32ToFloat64(b []byte) float64 {
+	bits := binary.BigEndian.Uint32(b)
+	f := math.Float32frombits(bits)
+	return float64(f)
+}
+
+// RTU16ToFloat64 converts 16 bit readings
+func RTU16ToFloat64(b []byte) float64 {
+	u := binary.BigEndian.Uint16(b)
+	return float64(u)
+}
+
+func rtuScaledInt32ToFloat64(b []byte, scalar float64) float64 {
 	unscaled := float64(binary.BigEndian.Uint32(b))
 	f := unscaled / scalar
 	return float64(f)
 }
 
-func MkRTUScaledIntToFloat64(scalar float64) RTUTransform {
+// MakeRTU32ScaledIntToFloat64 creates a 32 bit scaled reading transform
+func MakeRTU32ScaledIntToFloat64(scalar float64) RTUTransform {
 	return RTUTransform(func(b []byte) float64 {
-		return rtuScaledIntToFloat64(b, scalar)
+		return rtuScaledInt32ToFloat64(b, scalar)
 	})
 }
 
-func rtuToFloat64(b []byte) float64 {
-	bits := binary.BigEndian.Uint32(b)
-	f := math.Float32frombits(bits)
+func rtuScaledInt16ToFloat64(b []byte, scalar float64) float64 {
+	unscaled := float64(binary.BigEndian.Uint16(b))
+	f := unscaled / scalar
 	return float64(f)
+}
+
+// MakeRTU16ScaledIntToFloat64 creates a 16 bit scaled reading transform
+func MakeRTU16ScaledIntToFloat64(scalar float64) RTUTransform {
+	return RTUTransform(func(b []byte) float64 {
+		return rtuScaledInt16ToFloat64(b, scalar)
+	})
 }

--- a/scheduler.go
+++ b/scheduler.go
@@ -2,7 +2,6 @@ package sdm630
 
 import (
 	"log"
-	"math"
 	"time"
 )
 
@@ -49,7 +48,7 @@ func SetupScheduler(meters map[uint8]*Meter, qe *ModbusEngine) (*MeterScheduler,
 func (q *MeterScheduler) produceSnips(out QuerySnipChannel) {
 	for {
 		for _, meter := range q.meters {
-			sniplist := meter.Scheduler.Produce(meter.DeviceId)
+			sniplist := meter.Producer.Produce(meter.DeviceId)
 			for _, snip := range sniplist {
 				// Check if meter is still valid
 				if meter.GetState() != METERSTATE_UNAVAILABLE {
@@ -66,7 +65,7 @@ func (q *MeterScheduler) supervisor() {
 			if meter.GetState() == METERSTATE_UNAVAILABLE {
 				log.Printf("Attempting to ping unavailable meter %d", meter.DeviceId)
 				// inject probe snip - the re-enabling logic is in Run()
-				q.out <- meter.Scheduler.GetProbeSnip(meter.DeviceId)
+				q.out <- meter.Producer.Probe(meter.DeviceId)
 			}
 		}
 		time.Sleep(15 * time.Minute)
@@ -109,217 +108,4 @@ func (q *MeterScheduler) Run() {
 			}
 		}
 	}
-}
-
-// This is the interface each scheduler must implement.
-type Scheduler interface {
-	Produce(devid uint8) []QuerySnip
-	GetProbeSnip(devid uint8) QuerySnip
-}
-
-// ####################################################################
-// Round-Robin Scheduler for the Eastron SDM Devices
-// ####################################################################
-type SDMRoundRobinScheduler struct {
-}
-
-func NewSDMRoundRobinScheduler() *SDMRoundRobinScheduler {
-	return &SDMRoundRobinScheduler{}
-}
-
-func (s *SDMRoundRobinScheduler) GetProbeSnip(devid uint8) (retval QuerySnip) {
-	retval = QuerySnip{DeviceId: devid, FuncCode: ReadInputReg,
-		OpCode: OpCodeSDML1Voltage, Value: math.NaN(), Description: "L1 Voltage (V)", IEC61850: "VolLocPhsA"}
-	return retval
-}
-
-func (s *SDMRoundRobinScheduler) Produce(devid uint8) (retval []QuerySnip) {
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg,
-		OpCode: OpCodeSDML1Voltage, Value: math.NaN(), Description: "L1 Voltage (V)", IEC61850: "VolLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2Voltage, Value: math.NaN(),
-		Description: "L2 Voltage (V)", IEC61850: "VolLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3Voltage, Value: math.NaN(),
-		Description: "L3 Voltage (V)", IEC61850: "VolLocPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML1Current, Value: math.NaN(),
-		Description: "L1 Current (A)", IEC61850: "AmpLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2Current, Value: math.NaN(),
-		Description: "L2 Current (A)", IEC61850: "AmpLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3Current, Value: math.NaN(),
-		Description: "L3 Current (A)", IEC61850: "AmpLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML1Power, Value: math.NaN(),
-		Description: "L1 Power (W)", IEC61850: "WLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2Power, Value: math.NaN(),
-		Description: "L2 Power (W)", IEC61850: "WLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3Power, Value: math.NaN(),
-		Description: "L3 Power (W)", IEC61850: "WLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML1Cosphi, Value: math.NaN(),
-		Description: "L1 Cosphi", IEC61850: "AngLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2Cosphi, Value: math.NaN(),
-		Description: "L2 Cosphi", IEC61850: "AngLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3Cosphi, Value: math.NaN(),
-		Description: "L3 Cosphi", IEC61850: "AngLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML1Import, Value: math.NaN(),
-		Description: "L1 Import (kWh)", IEC61850: "TotkWhImportPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2Import, Value: math.NaN(),
-		Description: "L2 Import (kWh)", IEC61850: "TotkWhImportPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3Import, Value: math.NaN(),
-		Description: "L3 Import (kWh)", IEC61850: "TotkWhImportPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDMTotalImport, Value: math.NaN(),
-		Description: "Total Import (kWh)", IEC61850: "TotkWhImport"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML1Export, Value: math.NaN(),
-		Description: "L1 Export (kWh)", IEC61850: "TotkWhExportPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2Export, Value: math.NaN(),
-		Description: "L2 Export (kWh)", IEC61850: "TotkWhExportPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3Export, Value: math.NaN(),
-		Description: "L3 Export (kWh)", IEC61850: "TotkWhExportPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDMTotalExport, Value: math.NaN(),
-		Description: "Total Export (kWh)", IEC61850: "TotkWhExport"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML1THDVoltageNeutral, Value: math.NaN(),
-		Description: "L1 Voltage to neutral THD (%)", IEC61850: "ThdVolPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML2THDVoltageNeutral, Value: math.NaN(),
-		Description: "L2 Voltage to neutral THD (%)", IEC61850: "ThdVolPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDML3THDVoltageNeutral, Value: math.NaN(),
-		Description: "L3 Voltage to neutral THD (%)", IEC61850: "ThdVolPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDMAvgTHDVoltageNeutral, Value: math.NaN(),
-		Description: "Average voltage to neutral THD (%)", IEC61850: "ThdVol"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadInputReg, OpCode: OpCodeSDMFrequency, Value: math.NaN(),
-		Description: "Frequency of supply voltages", IEC61850: "Freq"})
-
-	return retval
-}
-
-// ####################################################################
-// Round-Robin Scheduler for the Janitza B23 DIN-Rail meters
-// ####################################################################
-
-type JanitzaRoundRobinScheduler struct {
-}
-
-func NewJanitzaRoundRobinScheduler() *JanitzaRoundRobinScheduler {
-	return &JanitzaRoundRobinScheduler{}
-}
-
-func (s *JanitzaRoundRobinScheduler) GetProbeSnip(devid uint8) (retval QuerySnip) {
-	retval = QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeJanitzaL1Voltage, Value: math.NaN(), Description: "L1 Voltage (V)", IEC61850: "VolLocPhsA"}
-	return retval
-}
-
-func (s *JanitzaRoundRobinScheduler) Produce(devid uint8) (retval []QuerySnip) {
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeJanitzaL1Voltage, Value: math.NaN(), Description: "L1 Voltage (V)", IEC61850: "VolLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeJanitzaL2Voltage, Value: math.NaN(), Description: "L2 Voltage (V)", IEC61850: "VolLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeJanitzaL3Voltage, Value: math.NaN(), Description: "L3 Voltage (V)", IEC61850: "VolLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL1Current, Value: math.NaN(),
-		Description: "L1 Current (A)", IEC61850: "AmpLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL2Current, Value: math.NaN(),
-		Description: "L2 Current (A)", IEC61850: "AmpLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL3Current, Value: math.NaN(),
-		Description: "L3 Current (A)", IEC61850: "AmpLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL1Power, Value: math.NaN(),
-		Description: "L1 Power (W)", IEC61850: "WLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL2Power, Value: math.NaN(),
-		Description: "L2 Power (W)", IEC61850: "WLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL3Power, Value: math.NaN(),
-		Description: "L3 Power (W)", IEC61850: "WLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL1Cosphi, Value: math.NaN(),
-		Description: "L1 Cosphi", IEC61850: "AngLocPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL2Cosphi, Value: math.NaN(),
-		Description: "L2 Cosphi", IEC61850: "AngLocPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL3Cosphi, Value: math.NaN(),
-		Description: "L3 Cosphi", IEC61850: "AngLocPhsC"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL1Import, Value: math.NaN(),
-		Description: "L1 Import (kWh)", IEC61850: "TotkWhImportPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL2Import, Value: math.NaN(),
-		Description: "L2 Import (kWh)", IEC61850: "TotkWhImportPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL3Import, Value: math.NaN(),
-		Description: "L3 Import (kWh)", IEC61850: "TotkWhImportPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaTotalImport, Value: math.NaN(),
-		Description: "Total Import (kWh)", IEC61850: "TotkWhImport"})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL1Export, Value: math.NaN(),
-		Description: "L1 Export (kWh)", IEC61850: "TotkWhExportPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL2Export, Value: math.NaN(),
-		Description: "L2 Export (kWh)", IEC61850: "TotkWhExportPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaL3Export, Value: math.NaN(),
-		Description: "L3 Export (kWh)", IEC61850: "TotkWhExportPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeJanitzaTotalExport, Value: math.NaN(),
-		Description: "Total Export (kWh)", IEC61850: "TotkWhExport"})
-	return retval
-}
-
-// ####################################################################
-// Round-Robin Scheduler for the Eastron SDM Devices
-// ####################################################################
-type DZGRoundRobinScheduler struct {
-}
-
-func NewDZGRoundRobinScheduler() *DZGRoundRobinScheduler {
-	return &DZGRoundRobinScheduler{}
-}
-
-func (s *DZGRoundRobinScheduler) GetProbeSnip(devid uint8) (retval QuerySnip) {
-	retval = QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL1Voltage, Value: math.NaN(),
-		Description: "L1 Voltage (V)", IEC61850: "VolLocPhsA",
-		Transform: MkRTUScaledIntToFloat64(100)}
-	return retval
-}
-
-func (s *DZGRoundRobinScheduler) Produce(devid uint8) (retval []QuerySnip) {
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL1Voltage, Value: math.NaN(), Description: "L1 Voltage (V)", IEC61850: "VolLocPhsA", Transform: MkRTUScaledIntToFloat64(100)})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL2Voltage, Value: math.NaN(), Description: "L2 Voltage (V)", IEC61850: "VolLocPhsB", Transform: MkRTUScaledIntToFloat64(100)})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL3Voltage, Value: math.NaN(), Description: "L3 Voltage (V)", IEC61850: "VolLocPhsC", Transform: MkRTUScaledIntToFloat64(100)})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeDZGL1Current, Value: math.NaN(),
-		Description: "L1 Current (A)", IEC61850: "AmpLocPhsA", Transform: MkRTUScaledIntToFloat64(1000)})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeDZGL2Current, Value: math.NaN(),
-		Description: "L2 Current (A)", IEC61850: "AmpLocPhsB", Transform: MkRTUScaledIntToFloat64(1000)})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg, OpCode: OpCodeDZGL3Current, Value: math.NaN(),
-		Description: "L3 Current (A)", IEC61850: "AmpLocPhsC", Transform: MkRTUScaledIntToFloat64(1000)})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL1Import, Value: math.NaN(),
-		Description: "L1 Import (kWh)", IEC61850: "TotkWhImportPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL2Import, Value: math.NaN(),
-		Description: "L2 Import (kWh)", IEC61850: "TotkWhImportPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL3Import, Value: math.NaN(),
-		Description: "L3 Import (kWh)", IEC61850: "TotkWhImportPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGTotalImport, Value: math.NaN(),
-		Description: "Total Import", IEC61850: "TotkWhImport",
-		Transform: MkRTUScaledIntToFloat64(1000)})
-
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL1Export, Value: math.NaN(),
-		Description: "L1 Export (kWh)", IEC61850: "TotkWhExportPhsA"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL2Export, Value: math.NaN(),
-		Description: "L2 Export (kWh)", IEC61850: "TotkWhExportPhsB"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGL3Export, Value: math.NaN(),
-		Description: "L3 Export (kWh)", IEC61850: "TotkWhExportPhsC"})
-	retval = append(retval, QuerySnip{DeviceId: devid, FuncCode: ReadHoldingReg,
-		OpCode: OpCodeDZGTotalExport, Value: math.NaN(),
-		Description: "Total Export", IEC61850: "TotkWhExport",
-		Transform: MkRTUScaledIntToFloat64(1000)})
-
-	return retval
 }

--- a/sdm.go
+++ b/sdm.go
@@ -54,6 +54,7 @@ func (p *SDMProducer) snip(devid uint8, opcode uint16, iec string) QuerySnip {
 		DeviceId:    devid,
 		FuncCode:    ReadInputReg,
 		OpCode:      opcode,
+		ReadLen:     2,
 		Value:       math.NaN(),
 		IEC61850:    iec,
 		Description: GetIecDescription(iec),

--- a/sdm.go
+++ b/sdm.go
@@ -1,0 +1,103 @@
+package sdm630
+
+import "math"
+
+const (
+	METERTYPE_SDM = "SDM"
+
+	/***
+	 * Opcodes as defined by Eastron.
+	 * See http://bg-etech.de/download/manual/SDM630Register.pdf
+	 * Please note that this is the superset of all SDM devices - some
+	 * opcodes might not work on some devicep.
+	 */
+	OpCodeSDML1Voltage   = 0x0000
+	OpCodeSDML2Voltage   = 0x0002
+	OpCodeSDML3Voltage   = 0x0004
+	OpCodeSDML1Current   = 0x0006
+	OpCodeSDML2Current   = 0x0008
+	OpCodeSDML3Current   = 0x000A
+	OpCodeSDML1Power     = 0x000C
+	OpCodeSDML2Power     = 0x000E
+	OpCodeSDML3Power     = 0x0010
+	OpCodeSDML1Import    = 0x015a
+	OpCodeSDML2Import    = 0x015c
+	OpCodeSDML3Import    = 0x015e
+	OpCodeSDMTotalImport = 0x0048
+	OpCodeSDML1Export    = 0x0160
+	OpCodeSDML2Export    = 0x0162
+	OpCodeSDML3Export    = 0x0164
+	OpCodeSDMTotalExport = 0x004a
+	OpCodeSDML1Cosphi    = 0x001e
+	OpCodeSDML2Cosphi    = 0x0020
+	OpCodeSDML3Cosphi    = 0x0022
+	//OpCodeL1THDCurrent         = 0x00F0
+	//OpCodeL2THDCurrent         = 0x00F2
+	//OpCodeL3THDCurrent         = 0x00F4
+	//OpCodeAvgTHDCurrent        = 0x00Fa
+	OpCodeSDML1THDVoltageNeutral  = 0x00ea
+	OpCodeSDML2THDVoltageNeutral  = 0x00ec
+	OpCodeSDML3THDVoltageNeutral  = 0x00ee
+	OpCodeSDMAvgTHDVoltageNeutral = 0x00F8
+	OpCodeSDMFrequency            = 0x0046
+)
+
+type SDMProducer struct {
+}
+
+func NewSDMProducer() *SDMProducer {
+	return &SDMProducer{}
+}
+
+func (p *SDMProducer) snip(devid uint8, opcode uint16, iec string) QuerySnip {
+	snip := QuerySnip{
+		DeviceId:    devid,
+		FuncCode:    ReadInputReg,
+		OpCode:      opcode,
+		Value:       math.NaN(),
+		IEC61850:    iec,
+		Description: GetIecDescription(iec),
+		Transform:   RTU32ToFloat64,
+	}
+	return snip
+}
+
+func (p *SDMProducer) Probe(devid uint8) QuerySnip {
+	return p.snip(devid, OpCodeSDML1Voltage, "VolLocPhsA")
+}
+
+func (p *SDMProducer) Produce(devid uint8) (res []QuerySnip) {
+	res = append(res, p.snip(devid, OpCodeSDML1Voltage, "VolLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2Voltage, "VolLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3Voltage, "VolLocPhsC"))
+	res = append(res, p.snip(devid, OpCodeSDML1Current, "AmpLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2Current, "AmpLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3Current, "AmpLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeSDML1Power, "WLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2Power, "WLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3Power, "WLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeSDML1Cosphi, "AngLocPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2Cosphi, "AngLocPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3Cosphi, "AngLocPhsC"))
+
+	res = append(res, p.snip(devid, OpCodeSDML1Import, "TotkWhImportPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2Import, "TotkWhImportPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3Import, "TotkWhImportPhsC"))
+	res = append(res, p.snip(devid, OpCodeSDMTotalImport, "TotkWhImport"))
+
+	res = append(res, p.snip(devid, OpCodeSDML1Export, "TotkWhExportPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2Export, "TotkWhExportPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3Export, "TotkWhExportPhsC"))
+	res = append(res, p.snip(devid, OpCodeSDMTotalExport, "TotkWhExport"))
+
+	res = append(res, p.snip(devid, OpCodeSDML1THDVoltageNeutral, "ThdVolPhsA"))
+	res = append(res, p.snip(devid, OpCodeSDML2THDVoltageNeutral, "ThdVolPhsB"))
+	res = append(res, p.snip(devid, OpCodeSDML3THDVoltageNeutral, "ThdVolPhsC"))
+	res = append(res, p.snip(devid, OpCodeSDMAvgTHDVoltageNeutral, "ThdVol"))
+
+	res = append(res, p.snip(devid, OpCodeSDMFrequency, "Freq"))
+
+	return res
+}


### PR DESCRIPTION
This PR moves meter implementations into their own files. Modbus reading gets an added `ReadLen` parameter that will allow to support additional meter types like Saia Burgess which only read a single register instead of two.