### PR TITLE
Implement source rate limiting

### DIFF
--- a/mqtt.go
+++ b/mqtt.go
@@ -27,6 +27,23 @@ func (r *RateMap) Allowed(rate int, topic string) bool {
 	return false
 }
 
+func (r *RateMap) WaitForCooldown(rate int, topic string) {
+	if rate == 0 {
+		return
+	}
+
+	t := (*r)[topic]
+	waituntil := t + int64(rate)*1e9 // use ns
+	now := time.Now().UnixNano()
+
+	if waituntil > now {
+		time.Sleep(time.Until(time.Unix(0, waituntil)))
+		(*r)[topic] = waituntil
+	} else {
+		(*r)[topic] = now
+	}
+}
+
 type MqttClient struct {
 	client    MQTT.Client
 	mqttTopic string


### PR DESCRIPTION
Currently, gosdm will keep polling all devices at highest possible speed. This leads to high CPU load and is of limited use for human consumption, e.g. in the web ui. Rate limiting is only applied for MQTT output.

With this PR, rate limiting is move to the device scheduler and will halt the scheduling go routine until the cool down time for the selected rate has been achieved. Rate limits are still specified in seconds, it needs to be verified if this should be milliseconds instead.

Builds on #88.