### PR TITLE
Synchronize application shutdown closing Run methods when broadcast channels are closed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ go.sum
 
 # created during build
 version.go
+launch.json

--- a/version.go
+++ b/version.go
@@ -1,6 +1,0 @@
-package sdm630
-
-const (
-	TAG = "v0.7.0"
-	HASH = "0635a05c"
-)


### PR DESCRIPTION
This PR addresses the following points:

- make rate limiting reusable by moving from MQTT output to scheduler
- synchronize application shutdown by making tee wait for attached consumers to shutdown
- have all tee consumers valididate input channel still open or close if not
- finally use these to allow homie to unpublish retained messages when sdm is shutdown

Clean version of #102, replaces #89